### PR TITLE
Add Node test script and sample test

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dev:client": "cd client && npm run dev",
     "build": "cd server && npm install && cd ../client && npm install && npm run build",
     "start": "cd server && npm start",
-    "start:server": "cd server && npm start"
+    "start:server": "cd server && npm start",
+    "test": "npm test -w server"
   },
   "devDependencies": {
     "concurrently": "^7.6.0"

--- a/server/index.js
+++ b/server/index.js
@@ -42,10 +42,10 @@ app.use((req, res, next) => {
 const path = require('path');
 app.use(express.static(path.join(__dirname, '../client/dist')));
 
-// Initialize OpenAI
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+// Initialize OpenAI only if an API key is available
+const openai = process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
 
 // Replicate not used - using OpenAI with audio post-processing instead
 
@@ -459,10 +459,14 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/dist/index.html'));
 });
 
-app.listen(port, '0.0.0.0', () => {
-  console.log(`🚀 Soooounds backend server running on http://0.0.0.0:${port}`);
-  console.log(`🌍 PORT environment variable: ${process.env.PORT}`);
-  console.log(`🎨 OpenAI API Key: ${process.env.OPENAI_API_KEY ? 'Found' : 'Missing'}`);
-  console.log(`🔄 Replicate API Token: ${process.env.REPLICATE_API_TOKEN ? 'Found' : 'Missing'}`);
-  console.log(`📡 Server ready to accept connections on all interfaces`);
-});
+if (require.main === module) {
+  app.listen(port, '0.0.0.0', () => {
+    console.log(`🚀 Soooounds backend server running on http://0.0.0.0:${port}`);
+    console.log(`🌍 PORT environment variable: ${process.env.PORT}`);
+    console.log(`🎨 OpenAI API Key: ${process.env.OPENAI_API_KEY ? 'Found' : 'Missing'}`);
+    console.log(`🔄 Replicate API Token: ${process.env.REPLICATE_API_TOKEN ? 'Found' : 'Missing'}`);
+    console.log(`📡 Server ready to accept connections on all interfaces`);
+  });
+}
+
+module.exports = { app, generateAudioPrompt, applyAudioEffects };

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,0 +1,9 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { generateAudioPrompt } = require('./index');
+
+test('generateAudioPrompt returns base prompt', () => {
+  const audioFeatures = { volume: 0.5, centroid: 0.5, pitch: 50, energy: 0.05 };
+  const result = generateAudioPrompt(audioFeatures, 'minimal');
+  assert.equal(result, 'Digital art style, high quality, artistic variation');
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test index.test.js"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- add root and server npm test scripts
- export server functions and guard server startup for testing
- add basic generateAudioPrompt test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894aedebf70832ab2aa38d3fbae08c6